### PR TITLE
fix: books.py get book by id error message

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -65,5 +65,5 @@ async def delete_book(book_id: int) -> None:
 async def get_book(book_id: int) -> Book:
     book = db.get_book(book_id)
     if book is None:
-        raise HTTPException(status_code=404, detail="Book not found, this is a test")
+        raise HTTPException(status_code=404, detail="Book not found")
     return book


### PR DESCRIPTION
Changed the error message when an invalid {book_id} is entered to "Book not found"